### PR TITLE
Use element.remove() fallback for IE compatibility

### DIFF
--- a/responsive_waterfall.js
+++ b/responsive_waterfall.js
@@ -124,7 +124,7 @@
         // remove old column
         for (var i = 0; i < this.columns.length; i++) {
           var columnElem = this.columns[i];
-          columnElem.remove();
+          this.container.removeChild(columnElem);
         }
 
         // init new column


### PR DESCRIPTION
Replace Element.remove() with parentNode.removeChild() syntax to support IE 9-11.

